### PR TITLE
Improve responsive gallery and about section layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -109,6 +109,13 @@ a{color:var(--text);text-decoration:none}
 .marquee__track{display:flex; gap:2rem; white-space:nowrap; animation:marquee 24s linear infinite}
 .marquee__track span{letter-spacing:.06em; color:var(--muted)}
 @keyframes marquee{from{transform:translateX(0)} to{transform:translateX(-50%)}}
+@media (max-width: 960px){
+  .about__grid{grid-template-columns:1fr;}
+  .about__stats{grid-template-columns: repeat(2, 1fr);}
+}
+@media (max-width: 640px){
+  .about__stats{grid-template-columns:1fr;}
+}
 
 /* Projects */
 .filters{display:flex; gap:.4rem; flex-wrap:wrap}
@@ -119,17 +126,17 @@ a{color:var(--text);text-decoration:none}
 .filter:hover{color:#fff; border-color:#ffffff30}
 .filter.is-active{background:#ffffff08; color:#fff; outline:var(--ring)}
 .grid{
-  display:grid; gap:1rem;
-  grid-template-columns: repeat(12, 1fr);
+  display:grid;
+  gap:1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
-.card{grid-column: span 4; background:transparent; border-radius:1rem; isolation:isolate; display:flex; flex-direction:column; gap:.75rem}
-.card:nth-child(6n+1){grid-column:span 8}
-.card:nth-child(8n+4){grid-column:span 6}
-@media (max-width: 980px){ .card{grid-column: span 6} .card:nth-child(6n+1), .card:nth-child(8n+4){grid-column: span 6}}
-@media (max-width: 640px){ .card{grid-column: span 12} }
+.card{background:transparent; border-radius:1rem; isolation:isolate; display:flex; flex-direction:column; gap:.75rem}
+@media (max-width: 480px){
+  .grid{grid-template-columns:minmax(0, 1fr);}
+}
 .card__inner{
   position:relative; width:100%; border:1px solid #ffffff14; border-radius:1rem; overflow:hidden; background:var(--soft);
-  cursor:pointer; padding:0;
+  cursor:pointer; padding:0; display:block; aspect-ratio:4 / 3;
 }
 .card img{width:100%; height:100%; object-fit:cover; transform:scale(1.0); transition:transform .5s ease}
 .card__inner:hover img{transform:scale(1.08)}


### PR DESCRIPTION
## Summary
- simplify the project gallery grid to use auto-fit columns so cards realign cleanly on small screens
- add a fixed aspect ratio to gallery cards to keep imagery consistent while resizing
- stack the about section layout and adjust stats columns for better readability on mobile

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fe36044f2c8331b9f6b1a38af48d43